### PR TITLE
form.errors still persist when reopen modal

### DIFF
--- a/resources/js/Pages/User/Create.vue
+++ b/resources/js/Pages/User/Create.vue
@@ -7,6 +7,7 @@ import SecondaryButton from '@/Components/SecondaryButton.vue';
 import SelectInput from '@/Components/SelectInput.vue';
 import TextInput from '@/Components/TextInput.vue';
 import { useForm } from '@inertiajs/vue3';
+import { watchEffect } from 'vue';
 
 const props = defineProps({
     show: Boolean,
@@ -35,6 +36,12 @@ const create = () => {
         onFinish: () => null,
     })
 }
+
+watchEffect(() => {
+    if (props.show) {
+        form.errors = {}
+    }
+})
 
 const roles = props.roles?.map(role => ({ label: role.name, value: role.name }))
 

--- a/resources/js/Pages/User/Edit.vue
+++ b/resources/js/Pages/User/Edit.vue
@@ -43,6 +43,7 @@ watchEffect(() => {
         form.name = props.user?.name
         form.email = props.user?.email
         form.role = props.user?.roles == 0 ? '' : props.user?.roles[0].name
+        form.errors = {}
     }
 })
 


### PR DESCRIPTION
user page form.errors persist when re-open modal (create, edit)

- create user using create button
- fill fields with empty value, this will generate error message
- close modal create user with errors
- re-open again create new user 